### PR TITLE
Make react-native a peerDependency to prevent naming collision with packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "uiview",
     "view"
   ],
-  "dependencies": {
-    "react-native": "^0.14.0"
+  "peerDependencies": {
+    "react-native": ">=0.14.0"
   },
   "author": "Dmitri Voronianski <dmitri.voronianski@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Fixes #6 
