### PR TITLE
Remove deprecated cloneWithProps

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -43,7 +43,7 @@ var EffectsViewComponent = React.createClass({
         return (
             <EffectsView {...nativeProps}>
                 {vibrantNode}
-                {React.Children.map(children, React.addons.cloneWithProps)}
+                {children}
             </EffectsView>
         );
     }


### PR DESCRIPTION
At first I wanted to update from `cloneWithProps` to `cloneElement`, but I didn't really see the point.

It works on the demo app :)
